### PR TITLE
Remove "Backend" from string

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -17,6 +17,6 @@
 
 <resources>
 	<string name="app_name">AppleWifiNlpBackend</string>
-	<string name="backend_name">Apple Wifi Backend</string>
+	<string name="backend_name">Apple Wi-Fi</string>
 	<string name="summary">Locate using Apple\'s online Wi-Fi database</string>
 </resources>


### PR DESCRIPTION
Avoid needless repetition: This is displayed in a menu where it already says in the title bar that backends are configured.